### PR TITLE
check user and group exist when registering plugin

### DIFF
--- a/t/register.t
+++ b/t/register.t
@@ -1,0 +1,34 @@
+#!perl
+
+use strict;
+use warnings;
+
+use Mojolicious::Lite;
+use Test::More tests => 2;
+
+eval {
+	plugin 'SetUserGroup' => {
+		user  => 'bad user name !!!!!',
+	};
+};
+
+my $error = $@;
+like(
+	$error,
+	qr/User "bad user name !!!!!" does not exist/,
+	'plugin croaks on bad user at register'
+);
+
+eval {
+	plugin 'SetUserGroup' => {
+		user  => (getpwuid($<))[0],
+		group => 'bad group name !!!!!',
+	};
+};
+
+$error = $@;
+like(
+	$error,
+	qr/Group "bad group name !!!!!" does not exist/,
+	'plugin croaks on bad user at register'
+);


### PR DESCRIPTION
if this check is only done in Mojo:IOLoop, and we have a bad user
or group, then we get into an infinite loop of Mojo::IOLoop being
stopped by the plugin, which is then started again by the manager.
if you're not watching the logs then the app appears to be running
but is in fact not able to do anything

check the user and group when the call to register the plugin is
made so we can exit early and inform the user that their set user
or groups are problematic - this will also be returned to command
line in the form of:

```
Can't load application ... User "$user" does not exist
```
